### PR TITLE
fix: prevent duplicate Qwen TTS sessions from async chat modal

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -623,9 +623,19 @@ const cleanupTimer = setInterval(() => {
 }, CLEANUP_INTERVAL_MS);
 cleanupTimer.unref();
 
+const buildCorsOrigins = (): string[] => {
+  const defaults = ['http://localhost:5173', 'http://127.0.0.1:5173'];
+  const extra = process.env.CORS_ALLOWED_ORIGINS?.trim();
+  if (!extra) {
+    return defaults;
+  }
+  const parsed = extra.split(',').map((o) => o.trim()).filter((o) => o.length > 0);
+  return [...new Set([...defaults, ...parsed])];
+};
+
 app.use(
   cors({
-    origin: 'http://localhost:5173',
+    origin: buildCorsOrigins(),
   }),
 );
 app.use(express.json({ limit: '2mb' }));
@@ -1117,6 +1127,8 @@ const autoEvaluateIteration = async (
       original: originalBase64,
       generated: renderedScreenshotBase64,
       mode: 'both',
+      sessionId,
+      iteration,
     });
     const result: IterationAutoEvaluationResult = {
       primaryScore: compareResult.primaryScore,


### PR DESCRIPTION
## Summary
- **Speech locking**: Added `isSpeakingRef` in-flight lock to `sendSystemSpeech` in CloneyPanel.tsx — drops concurrent TTS requests while one is active, releases on `audio-play-end`/`display_text` or 3s timeout. Prevents overlapping Qwen inference sessions and mixed voices.
- **Clone start mutex**: Added `cloneStartLockRef` (synchronous ref) to `startCloneLoop` in App.tsx — eliminates TOCTOU race on `isCloneRunning` React state that allowed duplicate upload+loop-start sequences.
- **Chat input gating**: Added `isSending` state to disable the chat input/send button during message processing, preventing rapid-fire user submissions.
- **SSE voice debounce**: Suppressed TTS on low-priority SSE events (`iteration-start`, `loop-error`) by passing `{ voice: false }` — only `iteration-complete` and `loop-complete` trigger voice.
- **Server improvements**: Configurable CORS origins via `CORS_ALLOWED_ORIGINS`, cached Puppeteer Chrome discovery, and more reliable completion marker detection in ralphProcessManager.

## Root Cause
The chat modal had zero client-side message serialization. Every `appendMessage('cloney', ...)` auto-triggered `sendSystemSpeech` → `ws.send(text-input with qwen3 TTS)` to the OLV WebSocket. When SSE loop events arrived in bursts, multiple TTS requests fired in milliseconds creating overlapping Qwen sessions. Additionally, `startCloneLoop` guarded with React state (`isCloneRunning`) which has async batching — two rapid calls could both pass the guard before either set it to `true`.

## Test plan
- [ ] Verify TypeScript compiles clean (`npx tsc --noEmit` in both client and server)
- [ ] Start a clone session and confirm only one Qwen TTS voice plays at a time
- [ ] Rapidly submit multiple chat messages — verify input disables during processing
- [ ] Trigger rapid SSE events (fast iterations) — verify no overlapping audio
- [ ] Double-click clone start — verify only one session is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)