### PR TITLE
fix: address 24 code review findings (security, performance, reliability)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@octokit/rest": "^22.0.1",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.2.1",
+        "helmet": "^8.1.0",
         "jszip": "^3.10.1",
         "multer": "^2.1.0",
         "pixelmatch": "^7.1.0",
@@ -4937,6 +4939,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5385,6 +5414,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@octokit/rest": "^22.0.1",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.2.1",
+    "helmet": "^8.1.0",
     "jszip": "^3.10.1",
     "multer": "^2.1.0",
     "pixelmatch": "^7.1.0",

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -329,7 +329,16 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function normalizeWheelDelta(event: React.WheelEvent<HTMLDivElement>): number {
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+function normalizeWheelDelta(event: WheelEvent): number {
   if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
     return event.deltaY * 15;
   }
@@ -344,9 +353,10 @@ function normalizeWheelDelta(event: React.WheelEvent<HTMLDivElement>): number {
 function App(): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const toastTimersRef = useRef<number[]>([]);
+  const nextToastIdRef = useRef(0);
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<number | null>(null);
-  const processedEventIdsRef = useRef<Set<number>>(new Set());
+  const lastProcessedEventIdRef = useRef<number>(-1);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const newestAnchorRef = useRef<HTMLDivElement | null>(null);
   const isAtNewestRef = useRef(true);
@@ -737,7 +747,7 @@ function App(): JSX.Element {
   }, [orderedIterations]);
 
   const addToast = useCallback((message: string) => {
-    const toastId = Date.now() + Math.floor(Math.random() * 1000);
+    const toastId = ++nextToastIdRef.current;
     setToasts((previous) => [...previous, { id: toastId, message }]);
 
     const timerId = window.setTimeout(() => {
@@ -795,10 +805,10 @@ function App(): JSX.Element {
       if (messageEvent.lastEventId) {
         const id = Number(messageEvent.lastEventId);
         if (Number.isInteger(id)) {
-          if (processedEventIdsRef.current.has(id)) {
+          if (id <= lastProcessedEventIdRef.current) {
             return;
           }
-          processedEventIdsRef.current.add(id);
+          lastProcessedEventIdRef.current = id;
           normalizedEventId = id;
         }
       }
@@ -956,35 +966,49 @@ function App(): JSX.Element {
         return { added: 0, rejected: 0 };
       }
 
-      let remainingSlots = MAX_FILES - files.length;
-      if (remainingSlots <= 0) {
-        addToast('Maximum reached. Remove an image before adding more.');
-        return { added: 0, rejected: incomingFiles.length };
-      }
-
-      const acceptedFiles: File[] = [];
       let typeRejections = 0;
       let sizeRejections = 0;
       let overflowRejections = 0;
+      let added = 0;
+      let isAlreadyAtCapacity = false;
 
-      for (const file of incomingFiles) {
-        if (!ACCEPTED_FILE_TYPES.has(file.type)) {
-          typeRejections += 1;
-          continue;
+      setFiles((previous) => {
+        let remainingSlots = MAX_FILES - previous.length;
+        if (remainingSlots <= 0) {
+          isAlreadyAtCapacity = true;
+          return previous;
         }
 
-        if (file.size > MAX_FILE_SIZE_BYTES) {
-          sizeRejections += 1;
-          continue;
+        const acceptedFiles: File[] = [];
+
+        for (const file of incomingFiles) {
+          if (!ACCEPTED_FILE_TYPES.has(file.type)) {
+            typeRejections += 1;
+            continue;
+          }
+
+          if (file.size > MAX_FILE_SIZE_BYTES) {
+            sizeRejections += 1;
+            continue;
+          }
+
+          if (remainingSlots === 0) {
+            overflowRejections += 1;
+            continue;
+          }
+
+          acceptedFiles.push(file);
+          remainingSlots -= 1;
         }
 
-        if (remainingSlots === 0) {
-          overflowRejections += 1;
-          continue;
-        }
+        added = acceptedFiles.length;
 
-        acceptedFiles.push(file);
-        remainingSlots -= 1;
+        return acceptedFiles.length > 0 ? [...previous, ...acceptedFiles] : previous;
+      });
+
+      if (isAlreadyAtCapacity) {
+        addToast('Maximum reached. Remove an image before adding more.');
+        return { added: 0, rejected: incomingFiles.length };
       }
 
       if (typeRejections > 0) {
@@ -999,16 +1023,12 @@ function App(): JSX.Element {
         addToast('Only 5 screenshots can be uploaded at once.');
       }
 
-      if (acceptedFiles.length > 0) {
-        setFiles((previous) => [...previous, ...acceptedFiles]);
-      }
-
       return {
-        added: acceptedFiles.length,
+        added,
         rejected: typeRejections + sizeRejections + overflowRejections,
       };
     },
-    [addToast, files.length],
+    [addToast],
   );
 
   const handleDragOver = useCallback(
@@ -1155,7 +1175,7 @@ function App(): JSX.Element {
     }
 
     closeEventStream();
-    processedEventIdsRef.current.clear();
+    lastProcessedEventIdRef.current = -1;
 
     setLoopStatus('running');
     setConnectionStatus('connecting');
@@ -1176,7 +1196,8 @@ function App(): JSX.Element {
     setIsScoreChartExpanded(false);
     setIsCloneRunning(true);
 
-    window.localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(cloneConfig));
+    const { githubToken, ...persistableConfig } = cloneConfig;
+    window.localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(persistableConfig));
     setCloneConfigErrors({});
 
     try {
@@ -1378,7 +1399,7 @@ function App(): JSX.Element {
   const dropZoneDisabled = files.length >= MAX_FILES;
 
   const handleComparisonWheel = useCallback(
-    (event: React.WheelEvent<HTMLDivElement>) => {
+    (event: WheelEvent) => {
       if (!comparisonViewportRef.current) {
         return;
       }
@@ -1412,6 +1433,22 @@ function App(): JSX.Element {
     },
     [comparisonViewportRef],
   );
+
+  useEffect(() => {
+    const viewport = comparisonViewportRef.current;
+    if (!viewport) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      handleComparisonWheel(event);
+    };
+
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      viewport.removeEventListener('wheel', handleWheel);
+    };
+  }, [handleComparisonWheel, currentComparisonIteration, currentComparisonImage, referencePreview]);
 
   const updateSliderPositionFromPointer = useCallback((clientX: number) => {
     const sliderCanvas = sliderCanvasRef.current;
@@ -1919,7 +1956,7 @@ function App(): JSX.Element {
                             </div>
                           ) : null}
 
-                          {card.commitUrl ? (
+                          {card.commitUrl && isSafeUrl(card.commitUrl) ? (
                             <p className="text-sm">
                               <a
                                 href={card.commitUrl}
@@ -2150,7 +2187,6 @@ function App(): JSX.Element {
                 className={`relative overflow-hidden rounded-xl border border-slate-700 bg-surface/70 ${
                   zoomScale > 1 ? 'cursor-grab active:cursor-grabbing' : 'cursor-zoom-in'
                 }`}
-                onWheel={handleComparisonWheel}
                 onPointerDown={beginPan}
                 onPointerMove={continuePan}
                 onPointerUp={endPan}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -94,9 +94,11 @@ export interface LoopStartRequest {
   config: LoopStartConfig;
 }
 
+export type LoopState = 'uploading' | 'analyzing' | 'cloning' | 'completed' | 'failed';
+
 export interface LoopStartResponse {
   sessionId: string;
-  state: string;
+  state: LoopState;
   currentIteration: number;
   maxIterations: number;
   targetScore: number;
@@ -119,7 +121,7 @@ export interface LoopStatusResponse {
     targetScore: number;
     githubUrl: string | null;
   };
-  state: string;
+  state: LoopState;
   currentIteration: number;
   maxIterations: number;
   lastScore: number | null;


### PR DESCRIPTION
## Summary

Comprehensive security and code quality fixes addressing **24 issues** identified by parallel code review (6 Opus agents reviewing ~8,600 LOC).

**Changes**: 11 files, +449/-123 lines across the full stack.

### Critical Security Fixes (6)
- **Authentication**: API key middleware on all `/api/` endpoints (#3)
- **Path Traversal**: UUID v4 validation for `sessionId` across 5 server files (#4)
- **Credential Exposure**: Strip `githubToken`/API keys from `localStorage` persistence (#5)
- **Environment Leak**: Allowlisted env vars for child process spawning (#6)
- **postMessage XSS**: Origin validation on both outgoing and incoming iframe messages (#7)
- **SSRF**: Protocol validation on `OPENAI_BASE_URL` environment variable (#8)

### High Severity Fixes (8)
- Chromium `data:` URI restricted to image/font MIME types (#9)
- Rate limiting via `express-rate-limit` on all endpoints (#10)
- LRU cache eviction (max 500) + session cleanup to prevent memory leaks (#11)
- SIGKILL escalation + process group kill for zombie prevention (#12)
- GitHub API rate limit detection (403/429) with retry-after (#13)
- `commitUrl` validated as HTTP(S) before rendering as `<a href>` (#14)
- Fire-and-forget async calls wrapped with `.catch()` error handlers (#15)
- Monotonic counter refs replacing collision-prone `Date.now()+random` IDs (#16)

### Medium Severity Fixes (8)
- `helmet` security headers middleware (#18)
- WebSocket reconnect cascade fixed via ref-stabilized callbacks (#19)
- Sync pixel comparison documented; fetch abort signals passed through (#20, #24)
- Browser crash recovery with `connected` health check (#21)
- Frontend perf: stale closure fix, non-passive wheel listener, chat cap at 200 (#22)
- `LoopState` union type, runtime mode validation, owner/repo regex (#23)

### Dependencies Added
- `express-rate-limit` - API rate limiting
- `helmet` - Security headers

## Test plan

- [ ] Verify server starts without errors
- [ ] Confirm API endpoints reject requests without `X-API-Key` header (when `API_KEY` env is set)
- [ ] Confirm rate limiting triggers on rapid requests (30/min general, 5/min heavy)
- [ ] Test file upload with crafted sessionId (e.g., `../../etc`) -- should reject
- [ ] Verify `githubToken` is NOT present in localStorage after config save
- [ ] Confirm postMessage only sends to configured iframe origin
- [ ] Check Chromium blocks `data:text/html` URIs but allows `data:image/png`
- [ ] Verify chat messages cap at 200 in CloneyPanel
- [ ] Run `npx tsc --noEmit` on both client and server -- zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)