### PR TITLE
fix: restrict data: URIs, browser health check, screenshot height cap

### DIFF
--- a/tests/unit/server/renderService.test.ts
+++ b/tests/unit/server/renderService.test.ts
@@ -36,6 +36,7 @@ const createBrowserHarness = (connected = true) => {
       }
     }),
     setContent: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(1024),
     screenshot: vi.fn().mockResolvedValue(Buffer.from('png-buffer')),
     close: vi.fn().mockResolvedValue(undefined),
   };


### PR DESCRIPTION
## Summary
- Restrict `data:` URI to `image/` and `font/` MIME types only; block `blob:`
- Add browser `connected` health check before reuse (crash recovery)
- Cap screenshot height at 8192px using `clip` to prevent OOM

Closes #9, #21

## Test plan
- [ ] `data:text/html` URIs are blocked in Puppeteer
- [ ] `data:image/png` URIs still allowed
- [ ] Browser crash triggers automatic reconnection
- [ ] Pages taller than 8192px are clamped

🤖 Generated with [Claude Code](https://claude.com/claude-code)