### PR TITLE
fix: resolve 8 integration issues blocking image ralph loop

### DIFF
--- a/src/server/compareService.ts
+++ b/src/server/compareService.ts
@@ -103,8 +103,10 @@ export class CompareError extends Error {
   }
 }
 
-const OPENAI_URL = `${process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1'}/chat/completions`;
-const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const OPENAI_URL = `${(process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/+$/, '')}/chat/completions`;
+const ANTHROPIC_URL = process.env.ANTHROPIC_BASE_URL
+  ? `${process.env.ANTHROPIC_BASE_URL.replace(/\/+$/, '')}/v1/messages`
+  : 'https://api.anthropic.com/v1/messages';
 const OPENAI_MODEL = process.env.VISION_COMPARE_MODEL ?? process.env.OPENAI_VISION_MODEL ?? 'gpt-4o';
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_VISION_MODEL ?? 'claude-3-5-sonnet-latest';
 const VISION_TIMEOUT_MS = 60_000;
@@ -388,7 +390,7 @@ const comparePixels = (images: NormalizedImages): PixelComparison => {
 
 const resolveProviderOrder = (): Provider[] => {
   const hasOpenAi = Boolean(process.env.OPENAI_API_KEY);
-  const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
+  const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN);
 
   if (hasOpenAi && hasAnthropic) {
     return ['openai', 'anthropic'];
@@ -475,7 +477,7 @@ const callOpenAiVision = async (originalPng: Buffer, generatedPng: Buffer): Prom
 };
 
 const callAnthropicVision = async (originalPng: Buffer, generatedPng: Buffer): Promise<VisionVerdict> => {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = process.env.ANTHROPIC_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN;
   if (!apiKey) {
     throw new CompareError('ANTHROPIC_API_KEY is not configured', 500, 'PROVIDER_UNAVAILABLE');
   }

--- a/src/server/visionAnalyzer.ts
+++ b/src/server/visionAnalyzer.ts
@@ -98,7 +98,7 @@ const TMP_ROOT = '/tmp';
 const MAX_IMAGES = 5;
 const ANALYZE_TIMEOUT_MS = 60_000;
 const CACHE_TTL_MS = 10 * 60 * 1000;
-const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.bmp']);
 const OPENAI_URL = process.env.OPENAI_BASE_URL
   ? `${process.env.OPENAI_BASE_URL.replace(/\/+$/, '')}/chat/completions`
   : 'https://api.openai.com/v1/chat/completions';
@@ -242,6 +242,12 @@ const detectMimeTypeFromPath = (filePath: string): string | null => {
   }
   if (extension === '.webp') {
     return 'image/webp';
+  }
+  if (extension === '.gif') {
+    return 'image/gif';
+  }
+  if (extension === '.bmp') {
+    return 'image/bmp';
   }
 
   return null;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -94,9 +94,11 @@ export interface LoopStartRequest {
   config: LoopStartConfig;
 }
 
+export type LoopState = 'uploading' | 'analyzing' | 'cloning' | 'completed' | 'failed';
+
 export interface LoopStartResponse {
   sessionId: string;
-  state: string;
+  state: LoopState;
   currentIteration: number;
   maxIterations: number;
   targetScore: number;
@@ -119,7 +121,7 @@ export interface LoopStatusResponse {
     targetScore: number;
     githubUrl: string | null;
   };
-  state: string;
+  state: LoopState;
   currentIteration: number;
   maxIterations: number;
   lastScore: number | null;


### PR DESCRIPTION
## Summary

- **CRITICAL:** Replace hardcoded `--tool omx` with dynamic tool detection (`omx` → `claude` → `codex` → `amp` fallback chain) in ralph process spawning
- **CRITICAL:** Expand Chromium browser discovery with 3 additional candidate paths (`/snap/bin/chromium`, `/usr/local/bin/chromium-browser`, `/usr/local/bin/google-chrome`) and `which` command fallback
- **HIGH:** Add `ralph-runtime/` and `src/` to HTML output search paths with recursive `index.html` fallback (max depth 3)
- **HIGH:** Respect `ANTHROPIC_BASE_URL` env var in compareService (matching visionAnalyzer pattern) and add `ANTHROPIC_AUTH_TOKEN` fallback for API key resolution
- **MEDIUM:** Strip trailing slashes from `OPENAI_BASE_URL` before appending path segments
- **MEDIUM:** Remove premature `<promise>COMPLETE</promise>` stdout marker detection; rely on clean process exit (code 0) for completion signaling
- **LOW:** Add `.gif` and `.bmp` to visionAnalyzer's `IMAGE_EXTENSIONS` and MIME type detection to match ralphProcessManager's accepted formats

## Files changed
| File | Fixes |
|------|-------|
| `src/server/ralphProcessManager.ts` | Tool detection fallback, remove completion marker |
| `src/server/renderService.ts` | Chromium discovery paths + `which` fallback |
| `src/server/index.ts` | HTML path search expansion + recursive fallback |
| `src/server/compareService.ts` | `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, slash handling |
| `src/server/visionAnalyzer.ts` | IMAGE_EXTENSIONS `.gif`/`.bmp` parity |

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] 33/33 unit tests pass across all 5 modified files
- [x] Pre-existing `githubCommitService.test.ts` failures (12) confirmed unrelated
- [ ] Manual verification: set `ANTHROPIC_BASE_URL` with trailing slash, confirm compareService constructs correct URL
- [ ] Manual verification: run ralph loop without `omx` installed, confirm fallback to `claude`
- [ ] Manual verification: place `index.html` in `workspace/ralph-runtime/`, confirm discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)